### PR TITLE
feat: Add month selector to transaction page to filter results

### DIFF
--- a/app/budgets.py
+++ b/app/budgets.py
@@ -1,13 +1,12 @@
-from datetime import date, datetime, timedelta
+from datetime import datetime
 from flask import Blueprint, jsonify, render_template, request
 
 from .auth import login_required
+from .date import CURRENT_MONTH, get_available_months
 from .db import Database
 
 
 bp = Blueprint("budgets", __name__)
-
-CURRENT_MONTH = datetime.now().replace(day=1).strftime("%Y-%m-%d")
 
 
 @bp.route("/budgets")
@@ -52,23 +51,6 @@ def budgets():
         months=available_months,
         selected_month=datetime.strptime(selected_month, "%Y-%m-%d"),
     )
-
-
-def get_available_months(starting_month=date(2020, 1, 1)):
-    """Get a list of all the months from starting_month to the current date.
-
-    This returns a list of date objects for each valid month.
-    """
-
-    now = datetime.now().date()
-    diff = now - starting_month
-
-    all_days = [starting_month + timedelta(days=i) for i in range(diff.days)]
-    month_trunc = [date.replace(day=1) for date in all_days]
-    unique_months = list(set(month_trunc))
-    ordered_months = sorted(unique_months, reverse=True)
-
-    return ordered_months
 
 
 @bp.route("/save_new_budget")

--- a/app/date.py
+++ b/app/date.py
@@ -1,0 +1,20 @@
+from datetime import date, datetime, timedelta
+
+CURRENT_MONTH = datetime.now().replace(day=1).strftime("%Y-%m-%d")
+
+
+def get_available_months(starting_month=date(2020, 1, 1)):
+    """Get a list of all the months from starting_month to the current date.
+
+    This returns a list of date objects for each valid month.
+    """
+
+    now = datetime.now().date()
+    diff = now - starting_month
+
+    all_days = [starting_month + timedelta(days=i) for i in range(diff.days)]
+    month_trunc = [date.replace(day=1) for date in all_days]
+    unique_months = list(set(month_trunc))
+    ordered_months = sorted(unique_months, reverse=True)
+
+    return ordered_months

--- a/app/static/js/transactions.js
+++ b/app/static/js/transactions.js
@@ -1,3 +1,12 @@
+function monthSelector() {
+  // Get the month value that's is selected
+  var month = $(this).val()
+
+  // show budgets of selected month
+  location.href = '/transactions?selected_month=' + month
+}
+
+
 function searchBarKeyPress(e) {
     //See notes about 'which' and 'key'
     if (e.keyCode == 13) {
@@ -51,6 +60,7 @@ function searchTransactions() {
 }
 
 function main() {
+  $('#month-selector').change(monthSelector);
   $('.category-save').on('change', highlightSaveButton);
   $('.save').click(saveCategoryButton);
   $('#search').click(searchTransactions);

--- a/app/templates/transactions.html
+++ b/app/templates/transactions.html
@@ -16,6 +16,18 @@
       </li>
     </ul>
   </div>
+
+  <div class="card-body">
+    <h3 class="card-title">Showing Transactions made in:
+      <select class="custom-select" id="month-selector">
+        {% for month in months %}
+        <option value="{{ month.strftime("%Y-%m-%d") }}"
+            {%- if month.strftime("%Y-%m-%d") == selected_month.strftime("%Y-%m-%d") %} selected {% endif -%}
+        > {{ month.strftime("%B %Y") }} </option>
+        {% endfor %}
+      </select>
+    </h3>
+  </div>
 </div>
 
 <div id="searchbar" class="input-group mb-3">


### PR DESCRIPTION
Added the month selector (from budgets page) to the transaction page to help reduce the number of transactions on a single page. It was starting to take too long to render all the rows and this is an "easy" quick solution to reduce the results. Search results only search on the selected month, which is not cool but works for now.....

List of changes:
* Moved date functions to `date.py` to easily reuse them
* Added date selector to transaction page and changed transactions URL to accept the `selected_month` URL parameter.
* Changed SQL for transaction list to be filtered on selected month.